### PR TITLE
Unified usage of "Accounts" and "Identities", "Profil" changed to "Moje knihovny"

### DIFF
--- a/local/cpk-front.mzk.cz/languages/cs-cpk.ini
+++ b/local/cpk-front.mzk.cz/languages/cs-cpk.ini
@@ -1,10 +1,12 @@
 @parent_ini = cs-mzk.ini
 
+;Změna v používání termínů "účet" a "identita"! Nyní: identita na portálu sdružuje účty z knihoven a sociálních sítí.
+
 ; Login
 login_with = Přihlašte se účtem zapojené knihovny
 login_other = Ostatní přihlášení
 login_last_used = V minulosti jste se přihlašovali přes instituci
-connect_with = Propojit s další identitou
+connect_with = Propojit s dalším účtem
 i_agree = Souhlasím
 i_disagree = Nesouhlasím
 
@@ -12,9 +14,9 @@ terms_of_use_disagree = Nesouhlasím s podmínkami použití
 terms_of_use_agree = Souhlasím s podmínkami použití
 terms_of_use = Podmínky použití
 
-delete-user-account = Smazat účet
+delete-user-account = Smazat portálovou identitu
 delete-user-account-confirm = Tímto z portálu smažete všechny Vaše propojené účty. Opravdu to chcete udělat?
-delete-user-account-not-confirmed = Nelze smazat účet bez Vašeho potvrzení.
+delete-user-account-not-confirmed = Nelze smazat identitu bez Vašeho potvrzení.
 
 eppn_missing_mail_subject = Váš IdP neposkytuje eppn
 api_not_available_mail_subject = Vaše API je z našeho portálu nedostupné
@@ -213,11 +215,11 @@ Create item = Vytvořit položku
 Edit item = Editovat položku
 Favorite authors = Oblíbení autoři
 
-;Identities
+;Identities (pro uživatele Accounts)
 Connect another account = Připojit další účet
 Linked accounts = Propojené účty
-identity_deleted = Identita smazána
-identity_deleted_description = Tato identita byla smazána poskytovatelem identity
+identity_deleted = Účet odpojen
+identity_deleted_description = Tento účet by smazán na straně knihovny či sociální sítě
 
 ;User's administration
 Settings = Nastavení
@@ -527,25 +529,25 @@ Develops = Vyvíjí
 Founder = Zřizovatel 
 Follow us = Sledujte nás
 
-;Library Cards & Identities
+;Library Cards & Identities (pro uživatele Accounts)
 Institutional Login = Přihlášení
-Library Cards = "Propojené identity"
-Library Card Name = "Název identity"
-Edit Library Card Name = "Upravit název identity"
-New Library Card Name = "Nový název identity"
-Place new Card name here = "Zadejte sem nový název identity ..."
-Card name cannot be empty = "Název identity nemůže být prázdný"
-Disconnect identity = "Odpojit identitu"
-Identity = "Identita"
-Identities were successfully connected = "Identity byly úspěšně propojeny"
-Identity disconnected = "Identita byla odpojena"
-Cannot disconnect the last identity = "Nelze odpojit poslední identitu"
-Cannot connect two accounts from the same institution = "Nelze propojit dvě identity ze stejné instituce"
+Library Cards = "Propojené účty"
+Library Card Name = "Název účtu"
+Edit Library Card Name = "Upravit název účtu"
+New Library Card Name = "Nový název účtu"
+Place new Card name here = "Zadejte sem nový název účtu ..."
+Card name cannot be empty = "Název účtu nemůže být prázdný"
+Disconnect identity = "Odpojit účet"
+Identity = "Účet"
+Identities were successfully connected = "Účty byly úspěšně propojeny"
+Identity disconnected = "Účet byl odpojen"
+Cannot disconnect the last identity = "Nelze odpojit poslední účet"
+Cannot connect two accounts from the same institution = "Nelze propojit více účtů ze stejné instituce"
 The consolidation has expired. Please authenticate again. = "Konsolidace účtů vypršela. Zkuste si účet propojit znovu."
 No token recieved after logging with another account = "Propojení, o které se pokoušíte, je neplatné. Povolte cookies a znovu se přihlašte."
 ;auth_cat_username_update_failed = "Cannot update new catalog username provided by IdP. You have more than one account within this institution - please disconnect one of these and try this again."
 Associated email = "Příslušný email"
-Cannot disconnect foreign identity = "Nelze odpojit cizí identitu"
+Cannot disconnect foreign identity = "Nelze odpojit cizí účet"
 You do not have any items checked out in this institution = "V této instituci nemáte žádné výpůjčky"
 You do not have any holds or recalls placed in this institution = "V této instituci nemáte žádné objednávky ani rezervace"
 You do not have any items in history = "V této instituci nemáte v historii žádné výpůjčky"
@@ -818,6 +820,7 @@ unknown = "neznámý"
 unspecified = "nespecifikovaný"
 
 ; MyResearch, profile, fines
+Profile = Moje knihovny
 You do not have any fines in this institution = V této instituci nemáte žádné pokuty ani poplatky
 Fines and Charges = Pokuty a poplatky
 show_others = Zobrazit další
@@ -4548,7 +4551,7 @@ Service Charge = Poplatek za služby
 Knihovny.cz = Knihovny.cz
 
 ; Profile translations
-profile_fetch_problem = "Profil se nepodařilo načíst"
+profile_fetch_problem = "Profil v této instituci se nepodařilo načíst"
 no_blocks_found = "V této instituci nemáte žádné pokuty ani poplatky"
 
 ; Notifications


### PR DESCRIPTION
Po domluvě změna používání termínů "Identita" a "Účet" ve smyslu: Portálová identita sdružuje účty z knihoven a sociálních sítí.
Důvod: Srozumitelnost pro uživatele (chápou, že identitu mají jen jednu, ale účtů můžou mít spoustu).
Ke stejné úpravě dojde i v en-cpk.ini.