### PR TITLE
Unified usage of terms "identity" and "account" en-cpk.ini

### DIFF
--- a/local/cpk-front.mzk.cz/languages/en-cpk.ini
+++ b/local/cpk-front.mzk.cz/languages/en-cpk.ini
@@ -1,10 +1,12 @@
 @parent_ini = en-mzk.ini
 
+;Changed usage of terms "account" and "identity"! For users "identity" works as unifying tool to link library and social network "accounts".  
+
 ; Login
 login_with = Login using connected library
 login_other = Alternative login
 login_last_used = Last time you have logged in using
-connect_with = Connect with another account
+connect_with = Connect with library account
 i_agree = I agree
 i_disagree = I disagree
 
@@ -12,9 +14,9 @@ terms_of_use_disagree = I disagree with the terms of use
 terms_of_use_agree = I agree with the terms of use
 terms_of_use = Terms of use
 
-delete-user-account = Delete account
-delete-user-account-confirm = You are going to delete all your consolidated accounts from the portal. Are you sure you want to do this?
-delete-user-account-not-confirmed = Cannot delete account without your confirmation
+delete-user-account = Delete portal identity
+delete-user-account-confirm = You are going to delete all your linked accounts from the portal. Are you sure you want to do this?
+delete-user-account-not-confirmed = Cannot delete identity without your confirmation
 
 eppn_missing_mail_subject = Your IdP does not provide eppn
 api_not_available_mail_subject = Your API is not available from our portal at the moment
@@ -213,11 +215,11 @@ Create item = Create item
 Edit item = Edit item
 Favorite authors = Favorite authors
 
-;Identities
+;Identities (Accounts for users)
 Connect another account = Connect another account
-Linked accounts = Linked accounts
-identity_deleted = Identity Deleted
-identity_deleted_description = This identity has beed deleted by the Identity Provider
+Linked accounts = Linked Accounts
+identity_deleted = Account disconnected
+identity_deleted_description = This account has been deleted within the library or social network.
 
 ;User's administration
 Settings = Settings
@@ -527,31 +529,31 @@ Develops = Develoment
 Founder = Founder 
 Follow us = Follow us
 
-;Library Cards & Identities
+;Library Cards & Identities (Accounts for users)
 Institutional Login = Login
-Library Cards = ; Library Cards
-Library Card Name = Library Card Name
-Edit Library Card Name = Edit Library Card Name
-New Library Card Name = New Library Card Name
-Place new Card name here = Place new Card name here 
-Card name cannot be empty = Card name cannot be empty 
-Disconnect identity = Disconnect identity
+Library Cards = ; Library Cards > Linked Accounts
+Library Card Name = Account name ;Library Card Name
+Edit Library Card Name = Edit account name ;Edit Library Card Name
+New Library Card Name = New account name ;New Library Card Name
+Place new Card name here = Place new account name here ;Place new Card name here 
+Card name cannot be empty = Account name cannot be empty ;Card name cannot be empty 
+Disconnect identity = Disconnect account
 
-Identity = Identity
-Identities were successfully connected = Identities were successfully connected
-Identity disconnected = Identity disconnected
-Cannot disconnect the last identity = Cannot disconnect the last identity
-Cannot connect two accounts from the same institution = Cannot connect two accounts from the same institution
-The consolidation has expired. Please authenticate again. = The consolidation has expired. Please authenticate again.
+Identity = Account
+Identities were successfully connected = Accounts were successfully connected
+Identity disconnected = Account disconnected
+Cannot disconnect the last identity = Cannot disconnect the last remaining account
+Cannot connect two accounts from the same institution = Linking more than one account within one institution is not possible.
+The consolidation has expired. Please authenticate again. = The consolidation of this account has expired. Please authenticate again.
 
 No token recieved after logging with another account = No token recieved after logging with another account
 uth_cat_username_update_failed = "Cannot update new catalog username provided by IdP. You have more than one account within this institution - please disconnect one of these and try this again."
 Associated email = Associated email
-Cannot disconnect foreign identity = Cannot disconnect foreign identity
+Cannot disconnect foreign identity = Cannot disconnect foreign account
 You do not have any items checked out in this institution = You do not have any items checked out in this institution
-You do not have any holds or recalls placed in this institution = You do not have any holds or recalls placed in this institution
+You do not have any holds or recalls placed in this institution = You do not have any orders of reservations placed in this institution
 You do not have any items in history = You do not have any items in history in this institution
-You already have this identity connected = You already have this identity connected
+You already have this identity connected = You already have this account connected
 
 
 ;Statistics
@@ -842,6 +844,7 @@ unknown = unknown
 unspecified = unspecified 
 
 ; MyResearch, profile, fines
+Profile = Library Cards
 You do not have any fines in this institution = You do not have any fines in this institution
 Fines and Charges = Fines and Charges
 show_others = Show others
@@ -4619,7 +4622,7 @@ element_help_facet_Conspectus = Hierarchical subject classification
 ;
 ie_not_supported = Internet Explorer not supported with this functionality
 
-;Holds and Recalls to Reservations and Orders. This needs to be checked and fully completed later
+;Holds and Recalls to Reservations and Orders
 Holds and Recalls = "Orders and Reservations"
 Your Holds and Recalls = "Your Orders and Reservations"
 Check Hold = "Check Order"
@@ -4631,7 +4634,7 @@ Recall This = "Reserve This"
 You do not have any holds or recalls placed = "You do not have any orders or reservations placed"
 
 ;Portal
-FAQ_first = Please, try to find an answer to your question in %s1frequently asked questions%s2 first.
+FAQ_first = Before contacting us, please try to find an answer to your question in %s1frequently asked questions (FAQ)%s2.
 
 ;Adresar knihoven
 look_for = Look for


### PR DESCRIPTION
Profile > Library Cards (in CS Moje knihovny) - it's just because of the clarity for users (but a bit confusing for us)
Edited the last occurance of "Holds and recalls" to "Orders and Reservations"